### PR TITLE
version 0.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: classyfireR
 Type: Package
 Title: R Interface to the ClassyFire RESTful API
-Version: 0.3.2
-Date: 2019-12-16
+Version: 0.3.3
+Date: 2020-02-17
 Authors@R: c(
     person("Tom", "Wilson", , "tpw2@aber.ac.uk", c("aut", "cre"),  comment = c(ORCID = "0000-0003-3112-4682")),
     person("Jasen", "Finch", , "jsf9@aber.ac.uk", "aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# classyfireR 0.3.3
+
+* Fix error when `get_classification` runs with no error codes, but no classification data is returned
+
 # classyfireR 0.3.2
 
 * Add check to `get_classification` for when a valid http status code (200) is returned but the content of the return is `{}`. This appears to be an error during InChIKey validation. 

--- a/R/get_classification.R
+++ b/R/get_classification.R
@@ -63,7 +63,9 @@ get_classification <- function(inchi_key)
 
     object@classification <- classification
 
-    object@direct_parent <- json_res$direct_parent
+    if (length(json_res$direct_parent) > 0) {
+      object@direct_parent <- json_res$direct_parent
+    }
 
     if (length(json_res$alternative_parents) > 0) {
       object@alternative_parents <-
@@ -90,9 +92,9 @@ get_classification <- function(inchi_key)
       object@external_descriptors <- tibble::tibble()
     }
 
-
-    object@description <- json_res$description
-
+    if (length(json_res$description) > 0) {
+      object@description <- json_res$description
+    }
 
     return(object)
   }

--- a/R/internals.R
+++ b/R/internals.R
@@ -52,7 +52,7 @@ parse_json_output <- function(json_res)
       stringr::str_c('level ', 5 + nIntermediate)
 
   } else {
-    class_tibble <- NULL
+    class_tibble <- tibble()
   }
   return(class_tibble)
 }

--- a/R/show-method.R
+++ b/R/show-method.R
@@ -27,6 +27,9 @@ setMethod('show', signature = 'ClassyFire',
             )), '\n')
 
 
+
+            if(nrow(object@classification) > 0){
+
             TreeList <- list()
             for (i in seq_along(object@classification$Level)) {
               if (i == length(object@classification$Level)) {
@@ -51,5 +54,6 @@ setMethod('show', signature = 'ClassyFire',
               )
 
            print(cli::tree(TreeDF))
+            }
 
           })


### PR DESCRIPTION
Fix error when `get_classification` runs with no error codes, but no classification data is returned